### PR TITLE
ifdef __debugbreak out for non-Windows systems. include <stdbool.h> for non-Windows systems

### DIFF
--- a/src/tb/tb_atomic.c
+++ b/src/tb/tb_atomic.c
@@ -40,6 +40,7 @@ bool tb_atomic_ptr_cmpxchg(void** address, void* old_value, void* new_value) {
 #elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
 #include <stdatomic.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 int tb_atomic_int_load(int* dst) {
     return atomic_load((atomic_int*) dst);

--- a/src/tb/tb_internal.h
+++ b/src/tb/tb_internal.h
@@ -518,15 +518,16 @@ do {                                 \
     }                                \
 } while (0)
 
-#define tb_assert_once(msg) (fprintf(stderr, "%s:%d: assert_once \"%s\"\n", __FILE__, __LINE__, msg), __debugbreak())
 
 #ifdef _WIN32
+#define tb_assert_once(msg) (fprintf(stderr, "%s:%d: assert_once \"%s\"\n", __FILE__, __LINE__, msg), __debugbreak())
 #define tb_panic(...)                     \
 do {                                      \
     printf(__VA_ARGS__);                  \
     __fastfail(FAST_FAIL_FATAL_APP_EXIT); \
 } while (0)
 #else
+#define tb_assert_once(msg) (fprintf(stderr, "%s:%d: assert_once \"%s\"\n", __FILE__, __LINE__, msg), __builtin_debugtrap())
 #define tb_panic(...)                     \
 do {                                      \
     printf(__VA_ARGS__);                  \


### PR DESCRIPTION
It was super easy to compile on Linux Mint after making these changes with the `build.py` script!